### PR TITLE
IN-600 : Added negative testcases for was-folders-v3 endpoint

### DIFF
--- a/tenable/io/v3/was/folders/api.py
+++ b/tenable/io/v3/was/folders/api.py
@@ -19,11 +19,13 @@ from requests import Response
 from tenable.io.v3.base.endpoints.explore import ExploreBaseEndpoint
 from tenable.io.v3.base.iterators.was_iterator import (CSVChunkIterator,
                                                        SearchIterator)
+from tenable.io.v3.was.folders.schema import FolderSchema
 
 
 class FoldersAPI(ExploreBaseEndpoint):
     _path = 'api/v3/was/folders'
     _conv_json = True
+    _schema = FolderSchema()
 
     def create(self, name: str) -> Dict:
         '''
@@ -41,7 +43,8 @@ class FoldersAPI(ExploreBaseEndpoint):
         Examples:
             >>> folder = tio.v3.was.folders.create('New Folder Name')
         '''
-        return self._post(json={'name': name})
+        payload = self._schema.dump(self._schema.load({'name': name}))
+        return self._post(json=payload)
 
     def delete(self, id: UUID) -> None:
         '''
@@ -78,7 +81,8 @@ class FoldersAPI(ExploreBaseEndpoint):
             >>> tio.v3.was.folders.edit('91843ecb-ecb8-48a3-b623-d4682c2594',
             ...     'Updated Folder Name')
         '''
-        return self._put(f'{id}', json={'name': name})
+        payload = self._schema.dump(self._schema.load({'name': name}))
+        return self._put(f'{id}', json=payload)
 
     def search(self,
                **kw

--- a/tenable/io/v3/was/folders/schema.py
+++ b/tenable/io/v3/was/folders/schema.py
@@ -1,0 +1,11 @@
+'''
+Folders API Endpoint Schemas
+'''
+from marshmallow import Schema, fields
+
+
+class FolderSchema(Schema):
+    '''
+    Schema for folders API
+    '''
+    name = fields.Str()

--- a/tests/io/v3/was/folders/test_folders_schema.py
+++ b/tests/io/v3/was/folders/test_folders_schema.py
@@ -1,0 +1,56 @@
+'''
+Testing the Folders Schema
+'''
+import pytest
+from marshmallow.exceptions import ValidationError
+from tenable.io.v3.was.folders.schema import FolderSchema
+
+FOLDER_NAME = 'folder'
+FOLDER = {
+    'name': FOLDER_NAME
+}
+
+
+def test_was_folders_schema(api):
+    '''
+    Test folders schema
+    '''
+    schema = FolderSchema()
+    payload = schema.dump(schema.load(FOLDER))
+    assert payload == FOLDER
+
+
+def test_was_folders_schema_name_typeerror():
+    '''
+    Test to raise exception when type of request header name parameter does not match the expected type.
+    '''
+    schema = FolderSchema()
+    payload = {
+        'name': 00
+    }
+    with pytest.raises(ValidationError):
+        schema.load(payload)
+
+
+def test_was_folder_edit_name_typeerror(api):
+    '''test to raise the exception when missing required argument'''
+    with pytest.raises(TypeError):
+        api.v3.was.folders.edit(00)
+
+
+def test_was_folder_edit_name_validationerror(api):
+    '''test to raise the exception when value is not valid'''
+    with pytest.raises(ValidationError):
+        api.v3.was.folders.edit("Test", 00)
+
+
+def test_was_folder_create_typeerror(api):
+    '''test to raise the exception when pass extra argument'''
+    with pytest.raises(TypeError):
+        api.v3.was.folders.create(00, 00)
+
+
+def test_was_folder_create_validationerror(api):
+    '''test to raise the exception when value is not valid'''
+    with pytest.raises(ValidationError):
+        api.v3.was.folders.create(11)


### PR DESCRIPTION
# Description

This PR contains code-changes for [IN-600](https://jira.eng.tenable.com/browse/IN-600) - Added negative testcases for was-folders V3 endpoint

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
To test code-changes of this PR, I have run testcases of `pyTenable\tests\io\v3\was\folders`. All testcases of this module working fine and getting passed. please find attached snapshot.

![folder was](https://user-images.githubusercontent.com/101259057/165085885-e63a5ced-f333-4f6b-9c8c-0c31bb4ebc2f.PNG)

Also I have run all test-cases of `pyTenable\tests` and it is getting passed. please find attached snapshot.

![was folder all tc](https://user-images.githubusercontent.com/101259057/165085918-9de32dcd-6b61-4dc1-ae9c-a61c2e6f8701.PNG)

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
