### PR TITLE
IN-605-Negative testcases for user-templates WAS

### DIFF
--- a/tests/io/v3/was/user_templates/test_user_templates_schema.py
+++ b/tests/io/v3/was/user_templates/test_user_templates_schema.py
@@ -1,6 +1,9 @@
 '''
 Test User Template Schema
 '''
+import pytest
+from marshmallow.exceptions import ValidationError
+
 from tenable.io.v3.was.user_templates.schema import (PermissionSchema,
                                                      UserTemplateSchema)
 
@@ -35,3 +38,153 @@ def test_permission_schema():
     '''
     schema = PermissionSchema()
     assert permission_obj == schema.dump(schema.load(permission_obj))
+
+
+def test_user_template_schema_parameters_type_error():
+    '''
+    Test to raise exception when values of name, default_permissions, description, owner_id, results_visibility
+    parameters of UserTemplate schema do not match the expected type.
+    '''
+    payload = {
+        'name': 1,
+        'default_permissions': 1,
+        'description': 1,
+        'owner_id': 123,
+        'results_visibility': 1
+    }
+    with pytest.raises(ValidationError) as validation_error:
+        UserTemplateSchema().load(payload)
+    assert len(validation_error.value.messages) == 5, "Test case should raise validation errors for five parameters."
+
+    assert len(validation_error.value.messages['name']) == 1, \
+        "Only one validation error should be raised by test-case for name parameter."
+    assert len(validation_error.value.messages['default_permissions']) == 1, \
+        "Only one validation error should be raised by test-case for default_permissions parameter."
+    assert len(validation_error.value.messages['description']) == 1, \
+        "Only one validation error should be raised by test-case for description parameter."
+    assert len(validation_error.value.messages['owner_id']) == 1, \
+        "Only one validation error should be raised by test-case for owner_id parameter."
+    assert len(validation_error.value.messages['results_visibility']) == 1, \
+        "Only one validation error should be raised by test-case for results_visibility parameter."
+
+    assert validation_error.value.messages['name'][0] == "Not a valid string.", \
+        "Invalid type validation error for name parameter is not raised by test-case."
+    assert validation_error.value.messages['default_permissions'][0] == "Not a valid string.", \
+        "Invalid type validation error for default_permissions parameter is not raised by test-case."
+    assert validation_error.value.messages['description'][0] == "Not a valid string.", \
+        "Invalid type validation error for description parameter is not raised by test-case."
+    assert validation_error.value.messages['owner_id'][0] == "Not a valid UUID.", \
+        "Invalid type validation error for owner_id parameter is not raised by test-case."
+    assert validation_error.value.messages['results_visibility'][0] == "Not a valid string.", \
+        "Invalid type validation error for results_visibility parameter is not raised by test-case."
+
+
+def test_user_template_schema_parameters_invalid_value():
+    '''
+    Test to raise exception when values of default_permissions, results_visibility parameters of UserTemplate schema
+    do not match the choices.
+    '''
+    payload = {
+        'default_permissions': 'test',
+        'results_visibility': 'test'
+    }
+    with pytest.raises(ValidationError) as validation_error:
+        UserTemplateSchema().load(payload)
+    assert len(validation_error.value.messages) == 2, "Test case should raise validation errors for two parameters."
+
+    assert len(validation_error.value.messages['default_permissions']) == 1, \
+        "Only one validation error should be raised by test-case for default_permissions parameter."
+    assert len(validation_error.value.messages['results_visibility']) == 1, \
+        "Only one validation error should be raised by test-case for results_visibility parameter."
+
+    assert validation_error.value.messages['default_permissions'][0].startswith("Must be one of"), \
+        "Invalid choice validation error for default_permissions parameter is not raised by test-case."
+    assert validation_error.value.messages['results_visibility'][0].startswith("Must be one of"), \
+        "Invalid choice validation error for results_visibility parameter is not raised by test-case."
+
+
+def test_permission_schema_required_parameters_missing_value_error():
+    '''
+    Test to raise exception when values for entity, entity_id, level, permissions_id required parameters of
+    Permission schema are not provided.
+    '''
+    with pytest.raises(ValidationError) as validation_error:
+        PermissionSchema().load({})
+    assert len(validation_error.value.messages) == 4, "Test case should raise validation errors for four parameters."
+
+    assert len(validation_error.value.messages['entity']) == 1, \
+        "Only one validation error should be raised by test-case for entity parameter."
+    assert len(validation_error.value.messages['entity_id']) == 1, \
+        "Only one validation error should be raised by test-case for entity_id parameter."
+    assert len(validation_error.value.messages['level']) == 1, \
+        "Only one validation error should be raised by test-case for level parameter."
+    assert len(validation_error.value.messages['permissions_id']) == 1, \
+        "Only one validation error should be raised by test-case for permissions_id parameter."
+
+    assert validation_error.value.messages['entity'][0].startswith("Missing data for required field."), \
+        "Missing data validation error for entity parameter is not raised by test-case."
+    assert validation_error.value.messages['entity_id'][0].startswith("Missing data for required field."), \
+        "Missing data validation error for entity_id parameter is not raised by test-case."
+    assert validation_error.value.messages['level'][0].startswith("Missing data for required field."), \
+        "Missing data validation error for level parameter is not raised by test-case."
+    assert validation_error.value.messages['permissions_id'][0].startswith("Missing data for required field."), \
+        "Missing data validation error for permissions_id parameter is not raised by test-case."
+
+
+def test_permission_schema_parameters_type_error():
+    '''
+    Test to raise exception when values of entity, entity_id, level, permissions_id parameters of Permission schema
+    do not match the expected type.
+    '''
+    payload = {
+        'entity': 1,
+        'entity_id': 123,
+        'level': 1,
+        'permissions_id': 123,
+    }
+    with pytest.raises(ValidationError) as validation_error:
+        PermissionSchema().load(payload)
+    assert len(validation_error.value.messages) == 4, "Test case should raise validation errors for four parameters."
+
+    assert len(validation_error.value.messages['entity']) == 1, \
+        "Only one validation error should be raised by test-case for entity parameter."
+    assert len(validation_error.value.messages['entity_id']) == 1, \
+        "Only one validation error should be raised by test-case for entity_id parameter."
+    assert len(validation_error.value.messages['level']) == 1, \
+        "Only one validation error should be raised by test-case for level parameter."
+    assert len(validation_error.value.messages['permissions_id']) == 1, \
+        "Only one validation error should be raised by test-case for permissions_id parameter."
+
+    assert validation_error.value.messages['entity'][0] == "Not a valid string.", \
+        "Invalid type validation error for entity parameter is not raised by test-case."
+    assert validation_error.value.messages['entity_id'][0] == "Not a valid UUID.", \
+        "Invalid type validation error for entity_id parameter is not raised by test-case."
+    assert validation_error.value.messages['level'][0] == "Not a valid string.", \
+        "Invalid type validation error for level parameter is not raised by test-case."
+    assert validation_error.value.messages['permissions_id'][0] == "Not a valid UUID.", \
+        "Invalid type validation error for permissions_id parameter is not raised by test-case."
+
+
+def test_permission_schema_parameters_invalid_value():
+    '''
+    Test to raise exception when values of entity, level parameters of Permission schema do not match the choices.
+    '''
+    payload = {
+        'entity': 'test',
+        'entity_id': '00000000-0000-0000-0000-000000000000',
+        'level': 'test',
+        'permissions_id': '00000000-0000-0000-0000-000000000000'
+    }
+    with pytest.raises(ValidationError) as validation_error:
+        PermissionSchema().load(payload)
+    assert len(validation_error.value.messages) == 2, "Test case should raise validation errors for two parameters."
+
+    assert len(validation_error.value.messages['entity']) == 1, \
+        "Only one validation error should be raised by test-case for entity parameter."
+    assert len(validation_error.value.messages['level']) == 1, \
+        "Only one validation error should be raised by test-case for level parameter."
+
+    assert validation_error.value.messages['entity'][0].startswith("Must be one of"), \
+        "Invalid choice validation error for entity parameter is not raised by test-case."
+    assert validation_error.value.messages['level'][0].startswith("Must be one of"), \
+        "Invalid choice validation error for level parameter is not raised by test-case."


### PR DESCRIPTION
# Description

In this PR, I have added negative test-cases for user-templates WAS. (IN-605)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

To test code-changes of this PR, I have run testcases of `pyTenable\tests\io\v3\was\user_templates\test_user_templates_schema.py` file. All testcases of this file are working fine and getting passed. please find attached snapshot :
![Negative_testcases_for_user_templates_was_schema_are_passed](https://user-images.githubusercontent.com/101327629/165499563-6db80bfd-3f17-4ac3-ab26-d48f45506874.jpg)


Also I have run all test-cases of `pyTenable\tests` folder and these are getting passed. please find attached snapshot :
![All_testcases_are_getting_passed](https://user-images.githubusercontent.com/101327629/165499600-bd7a38c0-001e-4520-8bac-2aa3d1f69e1f.jpg)



**Test Configuration**:
* Python Version(s) Tested: 3.10

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
